### PR TITLE
This adds stable16-24, with fixed CI versions, so that we can build/use this also in 2-5 years

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,87 @@ services:
   nextcloud-ephemeral-master:
     build:
       context: .
+      dockerfile: php7.4.Dockerfile
       args:
         BRANCH: master
     ports:
       - "80:80"
-  nextcloud-longlived-stable:
+  nextcloud-ephemeral-stable16:
     build:
       context: .
+      dockerfile: php7.2.Dockerfile
+      args:
+        BRANCH: stable16
+    ports:
+      - "80:80"
+  nextcloud-ephemeral-stable17:
+    build:
+      context: .
+      dockerfile: php7.2.Dockerfile
+      args:
+        BRANCH: stable17
+    ports:
+      - "80:80"
+  nextcloud-ephemeral-stable18:
+    build:
+      context: .
+      dockerfile: php7.2.Dockerfile
+      args:
+        BRANCH: stable18
+    ports:
+      - "80:80"
+  nextcloud-ephemeral-stable19:
+    build:
+      context: .
+      dockerfile: php7.2.Dockerfile
+      args:
+        BRANCH: stable19
+    ports:
+      - "80:80"
+  nextcloud-ephemeral-stable20:
+    build:
+      context: .
+      dockerfile: php7.4.Dockerfile
+      args:
+        BRANCH: stable20
+    ports:
+      - "80:80"
+  nextcloud-ephemeral-stable21:
+    build:
+      context: .
+      dockerfile: php7.4.Dockerfile
+      args:
+        BRANCH: stable21
+    ports:
+      - "80:80"
+  nextcloud-ephemeral-stable22:
+    build:
+      context: .
+      dockerfile: php7.4.Dockerfile
+      args:
+        BRANCH: stable22
+    ports:
+      - "80:80"
+  nextcloud-ephemeral-stable23:
+    build:
+      context: .
+      dockerfile: php7.4.Dockerfile
+      args:
+        BRANCH: stable23
+    ports:
+      - "80:80"
+  nextcloud-ephemeral-stable24:
+    build:
+      context: .
+      dockerfile: php7.4.Dockerfile
+      args:
+        BRANCH: stable24
+    ports:
+      - "80:80"
+  nextcloud-longlived-stable24:
+    build:
+      context: .
+      dockerfile: php7.4.Dockerfile
       args:
         BRANCH: stable24
     ports:
@@ -21,13 +95,6 @@ services:
       - apps-stable:/var/www/html/custom_apps
       - config-stable:/var/www/html/config
       - data-stable:/var/www/html/data
-  nextcloud-ephemeral-stable:
-    build:
-      context: .
-      args:
-        BRANCH: stable24
-    ports:
-      - "80:80"
   nextcloud-talk-stable:
     build:
       context: .

--- a/php7.2.Dockerfile
+++ b/php7.2.Dockerfile
@@ -1,0 +1,44 @@
+FROM nextcloudci/server:server-13
+
+ARG BRANCH="master"
+
+ENV EVAL=true
+
+RUN BRANCH="$BRANCH" /initnc.sh
+
+RUN su www-data -c "OC_PASS=user1 php /var/www/html/occ user:add --password-from-env --display-name='User One' user1"
+RUN su www-data -c "OC_PASS=user2 php /var/www/html/occ user:add --password-from-env --display-name='User Two' user2"
+RUN su www-data -c "OC_PASS=user3 php /var/www/html/occ user:add --password-from-env --display-name='User Three' user3"
+RUN su www-data -c "OC_PASS=test php /var/www/html/occ user:add --password-from-env --display-name='Test@Test' test@test"
+RUN su www-data -c "OC_PASS=test php /var/www/html/occ user:add --password-from-env --display-name='Test Spaces' 'test test'"
+RUN su www-data -c "php /var/www/html/occ user:setting user2 files quota 1G"
+RUN su www-data -c "php /var/www/html/occ group:add users"
+RUN su www-data -c "php /var/www/html/occ group:adduser users user1"
+RUN su www-data -c "php /var/www/html/occ group:adduser users user2"
+
+RUN su www-data -c "git clone --depth 1 -b $BRANCH https://github.com/nextcloud/activity.git /var/www/html/apps/activity/"
+RUN su www-data -c "php /var/www/html/occ app:enable activity"
+
+RUN su www-data -c "git clone --depth 1 -b $BRANCH https://github.com/nextcloud/text.git /var/www/html/apps/text/"
+RUN su www-data -c "php /var/www/html/occ app:enable text"
+
+RUN su www-data -c "git clone --depth 1 -b $BRANCH https://github.com/nextcloud/end_to_end_encryption.git /var/www/html/apps/end_to_end_encryption/"
+RUN su www-data -c "php /var/www/html/occ app:enable end_to_end_encryption"
+
+# RUN su www-data -c "git clone --depth 1 -b main https://github.com/nextcloud/calendar.git /var/www/html/apps/calendar/"
+# RUN su www-data -c "php /var/www/html/occ app:enable calendar"
+
+# RUN su www-data -c "git clone --depth 1 -b $BRANCH https://github.com/nextcloud/deck.git /var/www/html/apps/deck/"
+# RUN su www-data -c "php /var/www/html/occ app:enable deck"
+
+RUN su www-data -c "git clone --depth 1 -b $BRANCH https://github.com/nextcloud/spreed.git /var/www/html/apps/spreed/"
+RUN su www-data -c "php /var/www/html/occ app:enable spreed"
+
+RUN su www-data -c "git clone --depth 1 -b $BRANCH https://github.com/nextcloud/notifications.git /var/www/html/apps/notifications/"
+RUN su www-data -c "php /var/www/html/occ app:enable notifications"
+
+RUN su www-data -c "git clone --depth 1 -b $BRANCH https://github.com/nextcloud/external.git /var/www/html/apps/external/"
+RUN su www-data -c 'php /var/www/html/occ config:app:set external sites --value="{\"1\":{\"id\":1,\"name\":\"Nextcloud\",\"url\":\"https:\/\/www.nextcloud.com\",\"lang\":\"\",\"type\":\"link\",\"device\":\"\",\"icon\":\"external.svg\",\"groups\":[],\"redirect\":false},\"2\":{\"id\":2,\"name\":\"Forum\",\"url\":\"https:\/\/help.nextcloud.com\",\"lang\":\"\",\"type\":\"link\",\"device\":\"\",\"icon\":\"external.svg\",\"groups\":[],\"redirect\":false}}"'
+RUN su www-data -c "php /var/www/html/occ app:enable external"
+
+ENTRYPOINT /run.sh

--- a/php7.4.Dockerfile
+++ b/php7.4.Dockerfile
@@ -1,6 +1,4 @@
-# TODO use shallow-server when https://github.com/nextcloud/docker-ci/pull/371/files is merged
-FROM ghcr.io/nextcloud/continuous-integration-shallow-server:latest
-
+FROM ghcr.io/nextcloud/continuous-integration-shallow-server-php7.4:1
 
 ARG BRANCH="master"
 


### PR DESCRIPTION
Fix #1 

Whenever we need to use a newer php version, we have to create a new Dockerfile (and shallow server version).

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>