### PR TITLE
fix/docker-compose-syntax

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -5,4 +5,4 @@ cd $(dirname "$0")
 
 INSTANCE="nextcloud-$1"
 
-docker-compose build --no-cache "$INSTANCE"
+docker compose build --no-cache "$INSTANCE"

--- a/start.sh
+++ b/start.sh
@@ -8,4 +8,4 @@ INSTANCE="nextcloud-$1"
 PORT=${2:-80}
 
 # ./stop.sh
-PORT="$PORT" docker-compose up --detach "$INSTANCE"
+PORT="$PORT" docker compose up --detach "$INSTANCE"

--- a/stop.sh
+++ b/stop.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 cd $(dirname "$0")
 
-docker-compose down --remove-orphans --timeout 5
+docker compose down --remove-orphans --timeout 5


### PR DESCRIPTION
Migrates deprecated docker-compose to the native docker compose syntax integrated in (reasonably) recent docker releases